### PR TITLE
Refactor to parse into collection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    travis-env_vars (0.1.0)
+    travis-env_vars (0.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/travis/env_vars.rb
+++ b/lib/travis/env_vars.rb
@@ -27,6 +27,12 @@ module Travis
     end
     alias :to_collection :parse
 
+    def try_parse
+      parse
+    rescue ParseError
+      nil
+    end
+
     %i(to_pairs to_h to_strings to_s).each do |method|
       define_method(method) do
         to_collection.send(method)

--- a/lib/travis/env_vars.rb
+++ b/lib/travis/env_vars.rb
@@ -15,7 +15,7 @@ module Travis
       @obj = obj
     end
 
-    def parse(obj)
+    def parse
       case obj
       when ::String
         String.new(obj).parse
@@ -25,10 +25,7 @@ module Travis
         raise ArgumentError, "unsupported type #{obj.class} (given: #{obj.inspect})"
       end
     end
-
-    def to_collection
-      parse(obj)
-    end
+    alias :to_collection :parse
 
     %i(to_pairs to_h to_strings to_s).each do |method|
       define_method(method) do

--- a/lib/travis/env_vars/collection.rb
+++ b/lib/travis/env_vars/collection.rb
@@ -1,0 +1,23 @@
+require 'set'
+
+module Travis
+  class EnvVars
+    class Collection < Set
+      def to_pairs
+        map(&:to_pair)
+      end
+
+      def to_h
+        Hash[to_pairs]
+      end
+
+      def to_strings
+        map(&:to_s)
+      end
+
+      def to_s(delimiter = ' ')
+        to_strings.join(delimiter)
+      end
+    end
+  end
+end

--- a/lib/travis/env_vars/collection.rb
+++ b/lib/travis/env_vars/collection.rb
@@ -8,7 +8,7 @@ module Travis
       end
 
       def to_h
-        Hash[to_pairs]
+        ::Hash[to_pairs]
       end
 
       def to_strings
@@ -17,6 +17,10 @@ module Travis
 
       def to_s(delimiter = ' ')
         to_strings.join(delimiter)
+      end
+
+      def deep_merge(other)
+        other.union(self)
       end
     end
   end

--- a/lib/travis/env_vars/env_var.rb
+++ b/lib/travis/env_vars/env_var.rb
@@ -1,0 +1,31 @@
+module Travis
+  class EnvVars
+    class EnvVar
+      attr_reader :key, :value
+
+      def initialize(key, value)
+	@key, @value = key, value
+      end
+
+      def eql?(other)
+	hash === other.hash
+      end
+
+      def hash
+	key.to_s.to_i(32)
+      end
+
+      def to_pair
+	[key, value]
+      end
+
+      def to_s
+	"#{key}=#{value}"
+      end
+
+      def inspect
+	"<%s %s>" % [self.class.name, to_s]
+      end
+    end
+  end
+end

--- a/lib/travis/env_vars/env_var.rb
+++ b/lib/travis/env_vars/env_var.rb
@@ -8,7 +8,7 @@ module Travis
       end
 
       def eql?(other)
-	hash === other.hash
+	self.class.name == other.class.name && hash === other.hash
       end
 
       def hash
@@ -21,6 +21,35 @@ module Travis
 
       def to_s
 	"#{key}=#{value}"
+      end
+
+      def inspect
+	"<%s %s>" % [self.class.name, to_s]
+      end
+    end
+
+    class SecureEnvVar
+      attr_reader :str
+
+      def initialize(str)
+	@str = str
+      end
+
+      def eql?(other)
+	self.class.name == other.class.name && hash === other.hash
+      end
+
+      def hash
+	str.to_s.to_i(32)
+      end
+
+      def to_pair
+	# TODO: is this where decrypt would go?
+	[:secure, str]
+      end
+
+      def to_s
+	str
       end
 
       def inspect

--- a/lib/travis/env_vars/hash.rb
+++ b/lib/travis/env_vars/hash.rb
@@ -1,0 +1,20 @@
+require 'travis/env_vars/collection'
+require 'travis/env_vars/env_var'
+
+module Travis
+  class EnvVars
+    class Hash
+      attr_reader :hash
+
+      def initialize(hash)
+        @hash = hash
+      end
+
+      def parse
+        Collection.new.tap do |collection|
+          hash.each { |key, value| collection << EnvVar.new(key, value) }
+        end
+      end
+    end
+  end
+end

--- a/lib/travis/env_vars/hash.rb
+++ b/lib/travis/env_vars/hash.rb
@@ -12,8 +12,14 @@ module Travis
 
       def parse
         Collection.new.tap do |collection|
-          hash.each { |key, value| collection << EnvVar.new(key, value) }
+          hash.each { |key, value| collection << parse_pair(key, value) }
         end
+      end
+
+      private
+
+      def parse_pair(key, value)
+        key == :secure ? SecureEnvVar.new(value) : EnvVar.new(key, value)
       end
     end
   end

--- a/lib/travis/env_vars/hash.rb
+++ b/lib/travis/env_vars/hash.rb
@@ -10,6 +10,10 @@ module Travis
         @hash = hash
       end
 
+      def parses?
+        hash.keys.all? { |key| /^[A-Z_]+$/.match(key) }
+      end
+
       def parse
         Collection.new.tap do |collection|
           hash.each { |key, value| collection << parse_pair(key, value) }

--- a/lib/travis/env_vars/string.rb
+++ b/lib/travis/env_vars/string.rb
@@ -15,11 +15,19 @@ module Travis
 
       extend Forwardable
 
-      def_delegators :str, :check, :eos?, :peek, :pos, :scan, :skip, :string
+      def_delegators :str, :check, :eos?, :peek, :pos, :scan, :skip, :string, :reset
       attr_reader :str
 
       def initialize(str)
         @str = StringScanner.new(str.to_s.strip)
+      end
+
+      def parses?
+        parse
+        reset
+        true
+      rescue ParseError
+        false
       end
 
       def parse

--- a/lib/travis/env_vars/string.rb
+++ b/lib/travis/env_vars/string.rb
@@ -1,5 +1,7 @@
 require 'strscan'
 require 'forwardable'
+require 'travis/env_vars/collection'
+require 'travis/env_vars/env_var'
 
 module Travis
   class EnvVars
@@ -21,19 +23,16 @@ module Travis
       end
 
       def parse
-        pairs.to_h
+        collection = Collection.new
+        collection << take
+        collection << take while space
+        collection.tap { err('end of string') unless eos? }
       end
 
-      def pairs
-        pairs = [pair]
-        pairs += self.pairs while space
-        pairs.tap { err('end of string') unless eos? }
-      end
-
-      def pair
+      def take
         return unless key = self.key
         parts = [key, equal, value]
-        [parts.first, parts.last]
+        EnvVar.new(parts.first, parts.last)
       end
 
       def key

--- a/spec/travis/env_vars/hash_spec.rb
+++ b/spec/travis/env_vars/hash_spec.rb
@@ -1,16 +1,17 @@
-RSpec.describe Travis::EnvVars do
-  shared_examples_for 'parses' do |hash, expected|
-    specify do
-      result = described_class.new(hash).to_a
+RSpec.describe Travis::EnvVars::Hash do
+  shared_examples_for 'parses' do |desc = '', hash, expected|
+    specify(desc) do
+      result = Travis::EnvVars.new(hash).to_a
       expect(result).to eq expected
     end
   end
 
   let(:parse_error) { Travis::EnvVars::ParseError }
 
-  it_behaves_like 'parses', { FOO: 'foo', BAR: 'bar', BAZ: 'baz' }, [%(FOO=foo), %(BAR=bar), %(BAZ=baz)]
-  it_behaves_like 'parses', { FOO: '"foo"' }, [%(FOO="foo")]
-  it_behaves_like 'parses', { FOO: '$foo' }, [%(FOO=$foo)]
+  it_behaves_like 'parses', 'multiple env vars', { FOO: 'foo', BAR: 'bar', BAZ: 'baz' }, [%(FOO=foo), %(BAR=bar), %(BAZ=baz)]
+  it_behaves_like 'parses', 'a quoted env var', { FOO: '"foo"' }, [%(FOO="foo")]
+  it_behaves_like 'parses', 'a dollar value', { FOO: '$foo' }, [%(FOO=$foo)]
+  it_behaves_like 'parses', 'a secure env var', { secure: 'ABC123' }, [%(ABC123)]
 
   # TODO: should we care about weird cases when the input object is a hash?
   # it_behaves_like 'parses hash', { FOO: '' }, [%(FOO="")]

--- a/spec/travis/env_vars/hash_spec.rb
+++ b/spec/travis/env_vars/hash_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Travis::EnvVars do
+  shared_examples_for 'parses' do |hash, expected|
+    specify do
+      result = described_class.new(hash).to_a
+      expect(result).to eq expected
+    end
+  end
+
+  let(:parse_error) { Travis::EnvVars::ParseError }
+
+  it_behaves_like 'parses', { FOO: 'foo', BAR: 'bar', BAZ: 'baz' }, [%(FOO=foo), %(BAR=bar), %(BAZ=baz)]
+  it_behaves_like 'parses', { FOO: '"foo"' }, [%(FOO="foo")]
+  it_behaves_like 'parses', { FOO: '$foo' }, [%(FOO=$foo)]
+
+  # TODO: should we care about weird cases when the input object is a hash?
+  # it_behaves_like 'parses hash', { FOO: '' }, [%(FOO="")]
+end

--- a/spec/travis/env_vars/string_spec.rb
+++ b/spec/travis/env_vars/string_spec.rb
@@ -1,5 +1,5 @@
-RSpec.describe Travis::EnvVars do
-  subject { |e| described_class.new(e.description).to_a }
+RSpec.describe Travis::EnvVars::String do
+  subject { |e| Travis::EnvVars.new(e.description).to_a }
 
   let(:parse_error) { Travis::EnvVars::ParseError }
 


### PR DESCRIPTION
This makes a Collection (a set of EnvVar objects) the default
result of parsing, with all other formats (hash, string, array of
strings) defined on the Collection class.

This keeps the same behaviour that we have now, but allows
for the Collection to be used when merging env vars.

The next step would be to define SecureEnvVar, also as a set member
class (#eql?, #hash) which would allow collections of
secure and non-secure env vars to be merged.

Also removes the merge mode methods, which can't be defined here as
this parser will never operate on the full config hash.